### PR TITLE
Fix to the documenation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Now add a route to the end of your config.routes but only for development and te
 
 Create a single file called
 
-	specs/javascripts/spec.js.coffee
+	spec/javascripts/spec.js.coffee
 
 with the following content
 
@@ -30,9 +30,9 @@ with the following content
 
 This pulls in all your
 
-	specs/javascripts/*_spec.js.coffee
-	specs/javascripts/*_spec.js
-	specs/javascripts/*_spec.js.erb
+	spec/javascripts/*_spec.js.coffee
+	spec/javascripts/*_spec.js
+	spec/javascripts/*_spec.js.erb
 	etc
 
 into jasmine. For example


### PR DESCRIPTION
  The references to the 'specs' directory should be the 'spec' directory
  as that is what is required for the routing to successfully find the
  tests.
