### PR TITLE
Fixing haml requirement on runtime

### DIFF
--- a/lib/jasminerice.rb
+++ b/lib/jasminerice.rb
@@ -1,3 +1,4 @@
+require "haml"
 require "jasminerice/engine"
 
 module Jasminerice


### PR DESCRIPTION
s.add_dependcy "haml" informs bundle to install this gem but it is not loaded automatically in your gem.

Adding manual require for haml in gem main file fixes this issue.

See http://stackoverflow.com/questions/5015297/best-way-to-require-haml-on-rails3-engines for more details.
