### PR TITLE
Ability to include stylesheets in your jasmine specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,20 @@ Goto
 
 and there are your specs.
 
+---
+
+For including stylesheets in your specs, jasminerice uses a spec.css file. Create such a file next to the spec.js.coffee file:
+
+	spec/javascripts/spec.css
+  
+and in that file, use sprockets directives to include the right css files, e.g.
+
+	 /*
+	  *= require application
+	 */
+
+---
+
 Questions:
 
 	bradphelan@xtargets.com

--- a/app/views/jasminerice/spec/index.html.haml
+++ b/app/views/jasminerice/spec/index.html.haml
@@ -2,6 +2,7 @@
   %head
     %title Jasmine Spec Runner
     = stylesheet_link_tag "jasmine"
+    = stylesheet_link_tag "spec"
     = javascript_include_tag "jasminerice", :debug => Rails.env.development?
     = javascript_include_tag "spec", :debug => Rails.env.development?
     = csrf_meta_tags


### PR DESCRIPTION
This is a simple addition to jasminerice which enables users to include references to stylesheets to be loaded when the jasmine specs runner page is loaded. 
