### PR TITLE
Mount engine for the user

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,9 @@ your Gemfile so
 
 	gem "jasminerice"
 
-Now add a route to the end of your config/routes.rb but only for development and test
-
-	if ["development", "test"].include? Rails.env
-		mount Jasminerice::Engine => "/jasmine" 
-	end
+The engine is automatically mounted into your application in the development
+and test environments.  If you'd like to change that behavior, you can
+override the array `Jasminerice.environments` in an initializer.
 
 Create a single file called
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,3 +6,9 @@ Jasminerice::Engine.routes.draw do
 
   root :to => "spec#index"
 end
+
+Rails.application.routes.draw do
+  if Jasminerice.environments.include? Rails.env
+    mount Jasminerice::Engine => "/jasmine"
+  end
+end

--- a/lib/jasminerice.rb
+++ b/lib/jasminerice.rb
@@ -1,4 +1,6 @@
 require "jasminerice/engine"
 
 module Jasminerice
+  mattr_accessor :environments
+  self.environments = %w(development test)
 end


### PR DESCRIPTION
Howdy jasminerice pull request recipient(s)!

I've removed the need for the end user to mount `Jasminerice::Engine` in their config/routes.rb manually, preferring the gem to take care of that.  If users have a nonstandard environment set, the chosen environments can be overridden in e.g. `config/initializers/jasminerice.rb`.
