### PR TITLE
Not having the haml gem loaded prevents rails from finding spec/index.html.haml

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Setup For Rails 3.1
 This is a gem specifically for Rails 3.1. Just include it in
 your Gemfile so
 
+	gem "haml" # Unless included elsewhere in your gemfile
 	gem "jasminerice"
 
 The engine is automatically mounted into your application in the development


### PR DESCRIPTION
Haml is needed in the parent app to render engine views. Thought it should be called out explicitly for those who don't have haml installed.
