### PR TITLE
No need to have environments config. It is controlled from Gemfile anyway

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    jasminerice (0.0.7)
+    jasminerice (0.0.8)
       haml
 
 GEM

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,5 @@ Jasminerice::Engine.routes.draw do
 end
 
 Rails.application.routes.draw do
-  if Jasminerice.environments.include? Rails.env
-    mount Jasminerice::Engine => "/jasmine"
-  end
+  mount Jasminerice::Engine => "/jasmine"
 end

--- a/lib/jasminerice.rb
+++ b/lib/jasminerice.rb
@@ -2,6 +2,4 @@ require "jasminerice/engine"
 require 'haml'
 
 module Jasminerice
-  mattr_accessor :environments
-  self.environments = %w(development test)
 end


### PR DESCRIPTION
Always mount the Jasminerice engine.

There is no need to have `environments` config because it should be controlled from the Gemfile.
It directly functions as `:group` option in the Gemfile.

So instead of changing the Gemfile AND config variable you can only update the Gemfile:

``` ruby
gem 'jasminerice', :group => :test
# or
gem 'jasminerice' # always
#or
gem 'jasminerice', :group => [:test, :development, :staging]
```
