### PR TITLE
Allow some helper methods to be used in Jasminerice

### DIFF
--- a/app/controllers/jasminerice/spec_controller.rb
+++ b/app/controllers/jasminerice/spec_controller.rb
@@ -1,5 +1,11 @@
 module Jasminerice
   class SpecController <  Jasminerice::ApplicationController
+    begin
+      include Jasminerice::HelperMethods
+    rescue
+      puts "Declare your Jasminerice::HelperMethods (perhaps put inside lib/) to make helpers available to jasminerice fixtures"
+    end
+
     layout false
 
     def index


### PR DESCRIPTION
Currently, there is no way that you can use helper methods in jasminerice fixture.
The reason behind it is I want to reuse some views from the application (to avoid duplicate) which in turn rely on some helpers methods of devise
This pull request is very simple. I try to include Jasminerice::HelperMethods (which should be placed inside lib/) into SpecController. Incase Jasminerice::HelperMethods is not found, it just fall back to default (without any helpers)
