### PR TITLE
Allow routing to fixtures that are in subfolders

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Jasminerice::Engine.routes.draw do
   resources :spec, :controller => 'spec', :only => [:index] do
-    get "fixtures/:filename", :action => :fixtures
+    get "fixtures/*filename", :action => :fixtures
   end
-  match "fixtures/:filename", :to => "spec#fixtures#:filename"
+  match "fixtures/*filename", :to => "spec#fixtures"
 
   root :to => "spec#index"
 end


### PR DESCRIPTION
I've noticed that rendering fixtures in subfolders doesn't work.

This works:
spec/fixtures/fixture.html.haml

``` javascript
loadFixtures("fixture")
```

But this fails:
spec/fixtures/subfolder/fixture.html.haml

``` javascript
loadFixtures("subfolder/fixture")
```

Changing the routing parameter catching fixed the issue.
