### PR TITLE
Add both javascript and stylesheet paths

### DIFF
--- a/config/initializers/jasminerice.rb
+++ b/config/initializers/jasminerice.rb
@@ -1,1 +1,1 @@
-Rails.application.config.assets.paths << File.join(Rails.root, "spec", "javascripts")
+Rails.application.config.assets.paths << Rails.root.join("spec", "javascripts") << Rails.root.join("spec", "stylesheets")


### PR DESCRIPTION
The default html file includes both spec.js and spec.css but does not add the spec/stylesheets directory to the asset paths. This commit fixes that.
