### PR TITLE
Remove the haml requirement from jasminerice.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     jasminerice (0.0.8)
       coffee-rails
-      haml
 
 GEM
   remote: http://rubygems.org/
@@ -52,7 +51,6 @@ GEM
     erubis (2.7.0)
     execjs (1.3.0)
       multi_json (~> 1.0)
-    haml (3.1.3)
     hike (1.2.1)
     i18n (0.6.0)
     json (1.6.1)

--- a/app/views/jasminerice/spec/index.html.erb
+++ b/app/views/jasminerice/spec/index.html.erb
@@ -1,0 +1,12 @@
+<html>
+  <head>
+    <title>Jasmine Spec Runner</title>
+    <%= stylesheet_link_tag "jasmine" %>
+    <%= stylesheet_link_tag "spec" %>
+    <%= javascript_include_tag "jasminerice", :debug => Rails.env.development? %>
+    <%= javascript_include_tag "spec", :debug => Rails.env.development? %>
+    <%= csrf_meta_tags %>
+  </head>
+  <body>
+  </body>
+</html>

--- a/app/views/jasminerice/spec/index.html.haml
+++ b/app/views/jasminerice/spec/index.html.haml
@@ -1,9 +1,0 @@
-%html
-  %head
-    %title Jasmine Spec Runner
-    = stylesheet_link_tag "jasmine"
-    = stylesheet_link_tag "spec"
-    = javascript_include_tag "jasminerice", :debug => Rails.env.development?
-    = javascript_include_tag "spec", :debug => Rails.env.development?
-    = csrf_meta_tags
-  %body

--- a/jasminerice.gemspec
+++ b/jasminerice.gemspec
@@ -8,6 +8,5 @@ Gem::Specification.new do |s|
   s.authors     = ["Brad Phelan"]
   s.version     = "0.0.8"
   s.platform    = Gem::Platform::RUBY
-  s.add_dependency( 'haml' )
   s.add_dependency( 'coffee-rails' )
 end

--- a/lib/jasminerice.rb
+++ b/lib/jasminerice.rb
@@ -1,5 +1,4 @@
 require "jasminerice/engine"
-require 'haml'
 
 module Jasminerice
 end


### PR DESCRIPTION
Pulling in haml just for the index file was causing issues with an alpha version of sass (it repeatedly printed a warning when loading the Rails environment). Seeing as how haml was used for such a small thing it seemed better to simply remove it from jasminerice.
