### PR TITLE
Allow main rails config to determine :debug or not

### DIFF
--- a/app/views/jasminerice/spec/index.html.haml
+++ b/app/views/jasminerice/spec/index.html.haml
@@ -3,7 +3,7 @@
     %title Jasmine Spec Runner
     = stylesheet_link_tag "jasmine"
     = stylesheet_link_tag "spec"
-    = javascript_include_tag "jasminerice", :debug => Rails.env.development?
-    = javascript_include_tag "spec", :debug => Rails.env.development?
+    = javascript_include_tag "jasminerice"
+    = javascript_include_tag "spec"
     = csrf_meta_tags
   %body


### PR DESCRIPTION
This change removes the explicit setting of :debug => true in development mode. I have my debug set to false in development, as the usual effect is to speed up page requests by about 10 times.

With jasmine in particular, testing across about 70 javascript files, total browser refresh/test time goes from about 12 seconds to 1.5 for me. With rails-dev-tweaks, it goes from about 3 seconds to about 1.5 seconds, still a 50% increase.

Is there a reason you are not allowing config/environments/development.rb to set the asset debug flag?
