### PR TITLE
Remove reference to Jasminerice.environments in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ end
 
 The engine is automatically mounted into your application in the development
 and test environments. If you'd like to change that behavior, you can
-override the array `Jasminerice.environments` in an initializer.
+change which groups the gem is included in via the gemfile.
 
 Usage
 -----

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Jasminerice::Engine.routes.draw do
   root :to => "spec#index"
 end
 
-Rails.application.routes.draw do
-  mount Jasminerice::Engine => "/jasmine"
+if Jasminerice.mount
+  Rails.application.routes.draw do
+    mount Jasminerice::Engine => "/jasmine"
+  end
 end

--- a/lib/jasminerice.rb
+++ b/lib/jasminerice.rb
@@ -2,4 +2,6 @@ require "jasminerice/engine"
 require 'haml'
 
 module Jasminerice
+  mattr_accessor :mount
+  self.mount = true
 end


### PR DESCRIPTION
Changing the README to no longer reference Jasminerice.environments since it was removed in b083a7d
