### PR TITLE
Remove reference to Jasminerice.environments in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ end
 
 The engine is automatically mounted into your application in the development
 and test environments. If you'd like to change that behavior, you can
-override the array `Jasminerice.environments` in an initializer.
+change which groups the gem is included in via the gemfile.
 
 Usage
 -----


### PR DESCRIPTION
Changing the README to no longer reference Jasminerice.environments since it was removed in b083a7d
