### PR TITLE
Adding 'mount' property to Jasminerice module

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Jasminerice::Engine.routes.draw do
   root :to => "spec#index"
 end
 
-Rails.application.routes.draw do
-  mount Jasminerice::Engine => "/jasmine"
+if Jasminerice.mount
+  Rails.application.routes.draw do
+    mount Jasminerice::Engine => "/jasmine"
+  end
 end

--- a/lib/jasminerice.rb
+++ b/lib/jasminerice.rb
@@ -2,4 +2,6 @@ require "jasminerice/engine"
 require 'haml'
 
 module Jasminerice
+  mattr_accessor :mount
+  self.mount = true
 end


### PR DESCRIPTION
Adding a `mount` boolean property to Jasminerice module, so that applications can control whether to automatically mount the Jasminerice engine in their application. Defaults to true. This is useful when the application including the engine wants to mount the engine itself in its own routes.rb, so that it can control the order it is mounted in (to mount it above a wildcard-matching route, for instance).

This is kinda similar to the functionality that was removed in b083a7d, but instead of saying which environment(s) to mount the engine within, its just an on/off switch for mounting the engine at all. In my app, I have a catch-all, wildcard route at the end:

```
  match '*path', to: MyApp::Application::ROOT_PATH
```

and by letting the Jasminerice engine mount itself, it mounts after this catch-all route and I'm unable to navigate to the engine. When I set 'Jasminerice.mount = false' in an initializer and then have the following in my routes.rb:

```
  mount Jasminerice::Engine => '/jasmine'
  match '*path', to: MyApp::Application::ROOT_PATH`
```

Then my routes arrange in in the correct order.
