### PR TITLE
Make routes compatible with the Rails 4 beta

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Jasminerice::Engine.routes.draw do
   resources :spec, :controller => 'spec', :only => [:index] do
     get "fixtures/*filename", :action => :fixtures
   end
-  match "fixtures/*filename", :to => "spec#fixtures"
+  get "fixtures/*filename", :to => "spec#fixtures", :via => :any
 
   root :to => "spec#index"
 end


### PR DESCRIPTION
Use `:via => :any` when matching all HTTP verbs.

I wanted to share this in case it comes up again in the future. I haven't tested this with Rails 3 yet so can't be sure it's compatible with both versions.
