### PR TITLE
Updated Readme to more concisely show how to bootstrap test runner.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Create a file `spec/javascripts/spec.js.coffee` with the following content:
 
 	#=require_tree ./
 
+In the case where you need access to all your application javascript assets then create the file `spec/javascripts/spec.js.coffee` with the following contents:
+
+	#=require_tree ./
+	#=require_tree ../../app/assets/javascripts
+
 This pulls in all your specs from the `javascripts` directory into Jasmine:
 
 ```bash


### PR DESCRIPTION
I have included an example of how to load application javascript files in `spec/javascripts/spec.js.coffee`.  I spent a rather large amount of time looking into why my applications javascript environment was not being loaded in the test runners environment.  I stumbled across: (https://github.com/bradphelan/jasminerice/issues/26)  and thought it seemed beneficial to update the readme so that other people didn't run into the same issue.
