### PR TITLE
Upgrade jasmine-jquery to 1.4.2

### DIFF
--- a/app/assets/javascripts/jasminerice.js.coffee
+++ b/app/assets/javascripts/jasminerice.js.coffee
@@ -1,6 +1,6 @@
 #=require jasmine
 #=require jasmine-html
-#=require jasmine-jquery-1.3.2
+#=require jasmine-jquery-1.4.2
 
 (->
   execJasmine = ->


### PR DESCRIPTION
jasmine-jquery 1.4.2 is compatible with jQuery 1.8.

For example, toHandle matcher is break with jasmine-jquery 1.3.2 + jQuery 1.8 because **$(element).data("events")** is not supported any more in jQuery 1.8 but can be got by **$._data(element, "events")**. The 1.4.2 version supports that.
