### PR TITLE
Fixed typo in 'jasminerice:install' command in the README. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ change which groups the gem is included in via the gemfile.
 Optionally, you can run the installer
 
 ```bash
-rails g jasminerice::install
+rails g jasminerice:install
 ```
 
 This will add the required `spec.js.coffee` together with a sample spec and 


### PR DESCRIPTION
Smallest possible fix for a generator command in the README. Saves few seconds when copy/pasting.

Cheers,

Strika
