### PR TITLE
Allow runing a single spec from a specified suit 

### DIFF
--- a/app/controllers/jasminerice/spec_controller.rb
+++ b/app/controllers/jasminerice/spec_controller.rb
@@ -8,7 +8,7 @@ module Jasminerice
     layout false
 
     def index
-      @specenv = params[:environment].try(:concat, "_spec") || "spec"
+      @specsuite = params[:suite].try(:concat, "_spec") || "spec"
     end
 
     def fixtures

--- a/app/views/jasminerice/spec/index.html.haml
+++ b/app/views/jasminerice/spec/index.html.haml
@@ -4,6 +4,6 @@
     = stylesheet_link_tag "jasmine"
     = stylesheet_link_tag "spec"
     = javascript_include_tag "jasminerice"
-    = javascript_include_tag @specenv
+    = javascript_include_tag @specsuite
     = csrf_meta_tags
   %body

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,7 @@ Jasminerice::Engine.routes.draw do
     get "fixtures/*filename", :action => :fixtures
   end
   match "fixtures/*filename", :to => "spec#fixtures"
-
-  root :to => "spec#index"
+  match "/(:suite)", :to => "spec#index", defaults: { suite: false }
 end
 
 if Jasminerice.mount


### PR DESCRIPTION
When running a certain suite(with the :environment param) clicking on a
spec will not append the name of the suite. This commit fixes this
issue. I also renamed environment to suite to avoid confusion.
