### PR TITLE
Replace default suite param value with nil 

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Jasminerice::Engine.routes.draw do
     get "fixtures/*filename", :action => :fixtures
   end
   match "fixtures/*filename", :to => "spec#fixtures"
-  match "/(:suite)", :to => "spec#index", defaults: { suite: false }
+  match "/(:suite)", :to => "spec#index", defaults: { suite: nil }
 end
 
 if Jasminerice.mount


### PR DESCRIPTION
False will throw NoMethodError. Sorry I didn't catch this in the first place.
