### PR TITLE
Add asset debug override

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Optionally, you can run the installer
 rails g jasminerice:install
 ```
 
-This will add the required `spec.js.coffee` together with a sample spec and 
+This will add the required `spec.js.coffee` together with a sample spec and
 fixture to help get you started.
 
 Usage
@@ -43,12 +43,12 @@ Usage
 
 Create a file `spec/javascripts/spec.js.coffee` with the following content:
 
-	#=require_tree ./
+  #=require_tree ./
 
 In the case where you need access to all your application javascript assets then create the file `spec/javascripts/spec.js.coffee` with the following contents:
 
-	#=require_tree ./
-	#=require_tree ../../app/assets/javascripts
+  #=require_tree ./
+  #=require_tree ../../app/assets/javascripts
 
 This pulls in all your specs from the `javascripts` directory into Jasmine:
 
@@ -77,7 +77,7 @@ describe "Bar", ->
   it "it is not foo", ->
     v = new Bar()
     expect(v.foo()).toEqual(false)
-``` 
+```
 
 ### Stylesheets
 
@@ -120,7 +120,7 @@ Now start your server
 rails s
 ```
 
-Goto 
+Goto
 
 ```bash
 http://localhost:3000/jasmine
@@ -128,22 +128,34 @@ http://localhost:3000/jasmine
 
 and there are your specs.
 
+### Asset debugging
+
+You can override your current environment's `config.assets.debug` configuration per request
+by adding `?debug=false` or `?debug=true` to the jasmine path, eg.
+
+```bash
+http://localhost:3000/jasmine?debug=false
+```
+
+This will concatenate all your css and javascript into single file which can improve your
+suite's loading speed significantly.
+
 ### Compatibility with Require.js
 
-If you use [Require.js](http://requirejs.org/) in your project and need to load your 
+If you use [Require.js](http://requirejs.org/) in your project and need to load your
 modules in your jasmine specs, there is an option to prevent jasminerice from automatically
-executing the test runner before the modules are defined. This enables you to start the 
+executing the test runner before the modules are defined. This enables you to start the
 execution manually whenever you want in your `spec/javascripts/spec.js.coffee` file:
 
     #= require your/specs/and/other/stuff
     # at the end of this file add:
-    
+
     jasmine.rice.autoExecute = false
 
-    define 'jasmine.waitsfor.requirejs', ->  
+    define 'jasmine.waitsfor.requirejs', ->
     require ['jasmine.waitsfor.requirejs'], ->
       jasmine.getEnv().execute()
-      
+
 The shown example defines a dummy module in require.js that is required immediately on the next
 line. This is a simple hack to wait until require.js has initialized all modules and start the
 jasmine runner after that.

--- a/app/controllers/jasminerice/spec_controller.rb
+++ b/app/controllers/jasminerice/spec_controller.rb
@@ -9,6 +9,7 @@ module Jasminerice
 
     def index
       @specsuite = params[:suite].try(:concat, "_spec") || "spec"
+      @asset_options = %w(true false).include?(params[:debug]) ? { debug: params[:debug] == 'true' } : {}
     end
 
     def fixtures

--- a/app/views/jasminerice/spec/index.html.haml
+++ b/app/views/jasminerice/spec/index.html.haml
@@ -2,8 +2,8 @@
   %head
     %title Jasmine Spec Runner
     = stylesheet_link_tag "jasmine"
-    = stylesheet_link_tag "spec"
+    = stylesheet_link_tag "spec", @asset_options.clone
     = javascript_include_tag "jasminerice"
-    = javascript_include_tag @specsuite
+    = javascript_include_tag @specsuite, @asset_options.clone
     = csrf_meta_tags
   %body

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Jasminerice::Engine.routes.draw do
     get "fixtures/*filename", :action => :fixtures
   end
   match "fixtures/*filename", :to => "spec#fixtures"
-  match "/(:suite)", :to => "spec#index", defaults: { suite: false }
+  match "/(:suite)", :to => "spec#index", defaults: { suite: nil }
 end
 
 if Jasminerice.mount


### PR DESCRIPTION
Adds support to override current environment's config.assets.debug configuration with a url parameter so that all specs can be loaded in a single file. This can improve spec suite loading speed significantly in a big project that has lots of individual asset files.
