### PR TITLE
Add support for style fixtures

### DIFF
--- a/app/assets/javascripts/jasminerice.js.coffee
+++ b/app/assets/javascripts/jasminerice.js.coffee
@@ -18,6 +18,7 @@
     htmlReporter.specFilter spec
 
   jasmine.getFixtures().fixturesPath = 'jasmine/fixtures'
+  jasmine.getStyleFixtures().fixturesPath = 'jasmine/fixtures'
   jasmine.getJSONFixtures().fixturesPath = 'jasmine/fixtures/json'
 
   jasmine.rice = {}


### PR DESCRIPTION
the fixture path for style fixtures needs to be overridden just like
it does for html and json fixtures.
