### PR TITLE
Use ActionController#helper to include helpers

### DIFF
--- a/app/controllers/jasminerice/spec_controller.rb
+++ b/app/controllers/jasminerice/spec_controller.rb
@@ -1,9 +1,6 @@
 module Jasminerice
   class SpecController <  Jasminerice::ApplicationController
-    begin
-      include Jasminerice::HelperMethods
-    rescue
-    end
+    helper Jasminerice::HelperMethods rescue nil
 
     layout false
 


### PR DESCRIPTION
Instead of including the helper methods, making the method only
accessible through the controller instance, use the helper method, which
makes the methods available to the view contexts themselves and behaves
the way that users are used to Rails helpers behaving
