### PR TITLE
Add setup method and template

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ rails g jasminerice:install
 This will add the required `spec.js.coffee` together with a sample spec and
 fixture to help get you started.
 
+It will also add a intializer `config/initializers/jasminerice.rb` which
+can be used for easy setup of Jasminerice's options
+
 Usage
 -----
 

--- a/app/controllers/jasminerice/spec_controller.rb
+++ b/app/controllers/jasminerice/spec_controller.rb
@@ -14,7 +14,7 @@ module Jasminerice
     end
 
     def fixtures
-      render "spec/javascripts/fixtures/#{params[:filename]}"
+      render "#{Jasminerice.fixture_path}/#{params[:filename]}"
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,6 @@ end
 
 if Jasminerice.mount
   Rails.application.routes.draw do
-    mount Jasminerice::Engine => "/jasmine"
+    mount Jasminerice::Engine => Jasminerice.mount_at
   end
 end

--- a/lib/generators/jasminerice/install_generator.rb
+++ b/lib/generators/jasminerice/install_generator.rb
@@ -5,6 +5,7 @@ if ::Rails.version >= "3.1"
       source_root File.expand_path("../templates", __FILE__)
 
       def copy_files
+        copy_file "jasminerice.rb", "config/initializers/jasminerice.rb"
         copy_file "spec.js.coffee", "spec/javascripts/spec.js.coffee"
         copy_file 'foo_spec.js.coffee', 'spec/javascripts/foo_spec.js.coffee'
         copy_file 'spec.css', 'spec/javascripts/spec.css'

--- a/lib/generators/jasminerice/templates/jasminerice.rb
+++ b/lib/generators/jasminerice/templates/jasminerice.rb
@@ -1,0 +1,19 @@
+#Use this file to set configuration options for Jasminerice, all of
+#these are initialized to their respective defaults, but you can change
+#them here.
+Jasminerice.setup do |config|
+
+  #Tell Jasminerice to automatically mount itself in your application,
+  #if set to false, you must manually mount the engine in order to use
+  #Jasminerice
+  #config.mount = true
+
+  #If automatically mounting Jasminerice, specify the location that it
+  #should be mounted at.  Defaults to /jasmine, so you could access your
+  #tests at http://YOUR_SERVER_URL/jasmine
+  #config.mount_at = '/jasmine'
+
+  #Specify a path where your fixutures can be found.
+  #Defaults to 'spec/javascripts/fixtures'
+  #config.fixture_path = 'spec/javascripts/fixtures'
+end

--- a/lib/jasminerice.rb
+++ b/lib/jasminerice.rb
@@ -2,6 +2,21 @@ require "jasminerice/engine"
 require 'haml'
 
 module Jasminerice
+  # Determine whether or not to mount the Jasminerice engine implicitly. True/False
   mattr_accessor :mount
-  self.mount = true
+  @@mount = true
+
+  # Specify location at which to mount the engine, default to '/jasmine'
+  mattr_accessor :mount_at
+  @@mount_at = '/jasmine'
+
+  #Specify the path for fixutures, defaults to 'spec/javascripts/fixtures'
+  mattr_accessor :fixture_path
+  @@fixture_path = 'spec/javascripts/fixtures'
+
+  # Default way to setup Jasminerice. Run rails generate jasminerice:install to create
+  # a fresh initializer with all configuration values.
+  def self.setup
+    yield self
+  end
 end


### PR DESCRIPTION
Add a simple setup method which allows a user to specify some of the settings in Jasminerice, like the mount path and the fixture path.

Add a install template to the generator to place a default setup method in their initializers folder, much like Devise.
