### PR TITLE
Fixed typo in SpecController

### DIFF
--- a/app/controllers/jasminerice/spec_controller.rb
+++ b/app/controllers/jasminerice/spec_controller.rb
@@ -1,7 +1,7 @@
 module Jasminerice
   class SpecController <  Jasminerice::ApplicationController
    warn "Using Jasminerice::HelperMethods is deprecated and will be removed in a future release,"\
-        "please use Jasminerice::SpecHelper to define your helpers in the future" if defined?(Jasminrice::HelperMethods)
+        "please use Jasminerice::SpecHelper to define your helpers in the future" if defined?(Jasminerice::HelperMethods)
 
    helper Jasminerice::HelperMethods rescue nil
    helper Jasminerice::SpecHelper rescue nil


### PR DESCRIPTION
There was a typo when checking if Jasminerice::HelperMethods is defined 
