### PR TITLE
Rails 4 routing

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,8 @@ Jasminerice::Engine.routes.draw do
   resources :spec, :controller => 'spec', :only => [:index] do
     get "fixtures/*filename", :action => :fixtures
   end
-  get "fixtures/*filename", :to => "spec#fixtures"
-  get "/(:suite)", :to => "spec#index", defaults: { suite: nil }
+  match "fixtures/*filename", :to => "spec#fixtures", :via => :all
+  match "/(:suite)", :to => "spec#index", :via => :all
 end
 
 if Jasminerice.mount

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,8 @@ Jasminerice::Engine.routes.draw do
   resources :spec, :controller => 'spec', :only => [:index] do
     get "fixtures/*filename", :action => :fixtures
   end
-  match "fixtures/*filename", :to => "spec#fixtures"
-  match "/(:suite)", :to => "spec#index", defaults: { suite: nil }
+  get "fixtures/*filename", :to => "spec#fixtures"
+  get "/(:suite)", :to => "spec#index", defaults: { suite: nil }
 end
 
 if Jasminerice.mount

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,8 @@ Jasminerice::Engine.routes.draw do
   resources :spec, :controller => 'spec', :only => [:index] do
     get "fixtures/*filename", :action => :fixtures
   end
-  match "fixtures/*filename", :to => "spec#fixtures", :via => :all
-  match "/(:suite)", :to => "spec#index", :via => :all
+  get "fixtures/*filename", :to => "spec#fixtures"
+  get "/(:suite)", :to => "spec#index"
 end
 
 if Jasminerice.mount


### PR DESCRIPTION
This is a small fix to provide compatibility with Rails 4. I'm using `get` instead of `match`, as the routes should only accept GET requests, I believe. Thanks and thanks to @leifg as well.
