### PR TITLE
Restore compatibility with Ruby 1.8 by using hash rockets

### DIFF
--- a/app/controllers/jasminerice/spec_controller.rb
+++ b/app/controllers/jasminerice/spec_controller.rb
@@ -10,7 +10,7 @@ module Jasminerice
 
     def index
       @specsuite = params[:suite].try(:concat, "_spec") || "spec"
-      @asset_options = %w(true false).include?(params[:debug]) ? { debug: params[:debug] == 'true' } : {}
+      @asset_options = %w(true false).include?(params[:debug]) ? { :debug => params[:debug] == 'true' } : {}
     end
 
     def fixtures

--- a/spec/features/html_reporter_spec.rb
+++ b/spec/features/html_reporter_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-feature "Testing in the browser", js: true do
+feature "Testing in the browser", :js => true do
 
   scenario "gives me the expected results" do
     visit "/jasmine"

--- a/spec/features/install_generator_spec.rb
+++ b/spec/features/install_generator_spec.rb
@@ -1,12 +1,12 @@
 require "spec_helper"
 
-feature "Installing Jasminerice", aruba: true do
+feature "Installing Jasminerice", :aruba => true do
 
   before do
     unset_bundler_env_vars
     run_simple("bundle exec rails new testapp --skip-bundle")
     cd("testapp")
-    append_to_file("Gemfile", %{\ngem "jasminerice", path: "#{File.expand_path('../../../', __FILE__)}"\n})
+    append_to_file("Gemfile", %{\ngem "jasminerice", :path => "#{File.expand_path('../../../', __FILE__)}"\n})
     run_simple("bundle install --local")
   end
 

--- a/spec/support/aruba.rb
+++ b/spec/support/aruba.rb
@@ -1,14 +1,14 @@
 RSpec.configure do |config|
   config.include Aruba::Api
 
-  config.before(:each, aruba: true) do
+  config.before(:each, :aruba => true) do
     @aruba_timeout_seconds = 180
     FileUtils.rm_rf(current_dir)
     @__aruba_original_paths = (ENV['PATH'] || '').split(File::PATH_SEPARATOR)
     ENV['PATH'] = ([File.expand_path('bin')] + @__aruba_original_paths).join(File::PATH_SEPARATOR)
   end
 
-  config.after(:each, aruba: true) do
+  config.after(:each, :aruba => true) do
     ENV['PATH'] = @__aruba_original_paths.join(File::PATH_SEPARATOR)
     restore_env
   end


### PR DESCRIPTION
One of the projects I'm working is still running on Ruby 1.8. The library runs fine on that version with a few syntax modifications.
