### PR TITLE
Add DOCTYPE 

### DIFF
--- a/app/views/jasminerice/spec/index.html.erb
+++ b/app/views/jasminerice/spec/index.html.erb
@@ -1,3 +1,4 @@
+<!DOCTYPE html5>
 <html>
   <head>
     <title>Jasmine Spec Runner</title>


### PR DESCRIPTION
Added <!DOCTYPE html> to indicate browser should be in HTML5 mode rather than the quirks mode.

I suppose hypothetically the user should be able to configure the DOCTYPE to match the DOCTYPE used in their application.  However, going with html5 seems likely to work for developers using recent tools like jasminerice.  

In my case, I've got an app that uses jquery-migrate, and when running the jasmine specs (but not the regular app) i was getting a warning that [jQuery is not compatible quirks mode](https://github.com/jquery/jquery-migrate/blob/master/warnings.md#jqmigrate-jquery-is-not-compatible-with-quirks-mode)
