### PR TITLE
Daemonized Rails server cannot find jasmine fixtures

### DIFF
--- a/app/controllers/jasminerice/spec_controller.rb
+++ b/app/controllers/jasminerice/spec_controller.rb
@@ -1,10 +1,12 @@
 module Jasminerice
-  class SpecController <  Jasminerice::ApplicationController
-   warn "Using Jasminerice::HelperMethods is deprecated and will be removed in a future release,"\
+  class SpecController < Jasminerice::ApplicationController
+    warn "Using Jasminerice::HelperMethods is deprecated and will be removed in a future release,"\
         "please use Jasminerice::SpecHelper to define your helpers in the future" if defined?(Jasminerice::HelperMethods)
 
-   helper Jasminerice::HelperMethods rescue nil
-   helper Jasminerice::SpecHelper rescue nil
+    helper Jasminerice::HelperMethods rescue nil
+    helper Jasminerice::SpecHelper rescue nil
+
+    before_filter { prepend_view_path Rails.root.to_s }
 
     layout false
 

--- a/spec/controllers/spec_controller_spec.rb
+++ b/spec/controllers/spec_controller_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe Jasminerice::SpecController do
+  describe "view paths" do
+    before do
+      Jasminerice::SpecController.any_instance.stub(:render) { @view_paths = controller.view_paths }
+      get 'fixtures', :use_route => :jasminerice
+    end
+
+    subject { @view_paths.map(&:original_path_set).flatten.map(&:to_s) }
+
+    it { should include Rails.root.to_s }
+  end
+end


### PR DESCRIPTION
When the Rails server is started as daemon, e.g.

```
  rails server -d
```

jasminerice fails to load fixtures with the missing template error. The reason is that the current directory of the daemon is "/" instead of the Rails.root and the lookup for "spec/javascript/fixtures" fails.

A workaround is to add the following line to the application.rb:

```
config.paths['app/views'] << Rails.root.to_s
```
