### PR TITLE
Make it possible to configure paths to assets

### DIFF
--- a/lib/generators/jasminerice/templates/jasminerice.rb
+++ b/lib/generators/jasminerice/templates/jasminerice.rb
@@ -10,6 +10,9 @@ if defined?(Jasminerice) == 'constant'
     # you could access your tests at http://YOUR_SERVER_URL/jasmine
     #config.mount_at = '/jasmine'
 
+    # Specify paths with spec files to be included by the asset pipeline. Defaults to 'spec/javascripts' and 'spec/stylesheets'
+    #config.assets_paths = ["spec/javascripts", "spec/stylesheets"]
+
     # Specify a path where your fixutures can be found. Defaults to 'spec/javascripts/fixtures'
     #config.fixture_path = 'spec/javascripts/fixtures'
   end

--- a/lib/jasminerice.rb
+++ b/lib/jasminerice.rb
@@ -11,6 +11,12 @@ module Jasminerice
   mattr_accessor :fixture_path
   @@fixture_path = 'spec/javascripts/fixtures'
 
+  mattr_accessor :assets_paths
+  @@assets_paths = [
+    "spec/stylesheets",
+    "spec/javascripts"
+  ]
+
   # Default way to setup Jasminerice. Run rails generate jasminerice:install to create
   # a fresh initializer with all configuration values.
   def self.setup
@@ -21,8 +27,7 @@ module Jasminerice
     isolate_namespace Jasminerice
 
     initializer :assets, :group => :all do |app|
-      app.config.assets.paths << Rails.root.join("spec", "javascripts").to_s
-      app.config.assets.paths << Rails.root.join("spec", "stylesheets").to_s
+      app.config.assets.paths.concat(Jasminerice.assets_paths.collect{ |path| Rails.root.join(path).to_s })
     end
 
     config.after_initialize do |app|


### PR DESCRIPTION
My spec folder is located at /test/spec. This patch adds a way of specifying paths other than the default /spec.

Thanks for a great gem. Hope you find this patch useful. 
