### PR TITLE
Change fixtures paths from absolute to relative.

### DIFF
--- a/app/assets/javascripts/jasminerice.js.coffee
+++ b/app/assets/javascripts/jasminerice.js.coffee
@@ -17,9 +17,9 @@
   jasmineEnv.specFilter = (spec) ->
     htmlReporter.specFilter spec
 
-  jasmine.getFixtures().fixturesPath = '/jasmine/fixtures'
-  jasmine.getStyleFixtures().fixturesPath = '/jasmine/fixtures'
-  jasmine.getJSONFixtures().fixturesPath = '/jasmine/fixtures/json'
+  jasmine.getFixtures().fixturesPath = 'jasmine/fixtures'
+  jasmine.getStyleFixtures().fixturesPath = 'jasmine/fixtures'
+  jasmine.getJSONFixtures().fixturesPath = 'jasmine/fixtures/json'
 
   jasmine.rice = {}
   jasmine.rice.autoExecute = true


### PR DESCRIPTION
Fixes an issue where Jasmine is mounted in a non-standard place
(i.e. /mything/jasmine) and the fixtures are still served from
/jasmine/fixtures rather than /mything/jasmine/fixtures.
