### PR TITLE
Allow configuration of spec folder

### DIFF
--- a/lib/generators/jasminerice/templates/jasminerice.rb
+++ b/lib/generators/jasminerice/templates/jasminerice.rb
@@ -10,6 +10,9 @@ if defined?(Jasminerice) == 'constant'
     # you could access your tests at http://YOUR_SERVER_URL/jasmine
     #config.mount_at = '/jasmine'
 
+    # Specify a path where your specs can be found. Defaults to 'spec'
+    #config.spec_path = 'spec'
+
     # Specify a path where your fixutures can be found. Defaults to 'spec/javascripts/fixtures'
     #config.fixture_path = 'spec/javascripts/fixtures'
   end

--- a/lib/jasminerice.rb
+++ b/lib/jasminerice.rb
@@ -7,6 +7,10 @@ module Jasminerice
   mattr_accessor :mount_at
   @@mount_at = '/jasmine'
 
+  # Specify the path for specs, defaults to 'spec'
+  mattr_accessor :spec_path
+  @@spec_path = 'spec'
+
   #Specify the path for fixutures, defaults to 'spec/javascripts/fixtures'
   mattr_accessor :fixture_path
   @@fixture_path = 'spec/javascripts/fixtures'
@@ -21,8 +25,8 @@ module Jasminerice
     isolate_namespace Jasminerice
 
     initializer :assets, :group => :all do |app|
-      app.config.assets.paths << Rails.root.join("spec", "javascripts").to_s
-      app.config.assets.paths << Rails.root.join("spec", "stylesheets").to_s
+      app.config.assets.paths << Rails.root.join(Jasminerice.spec_path, "javascripts").to_s
+      app.config.assets.paths << Rails.root.join(Jasminerice.spec_path, "stylesheets").to_s
     end
 
     config.after_initialize do |app|

--- a/spec/dummy/config/initializers/jasminerice.rb
+++ b/spec/dummy/config/initializers/jasminerice.rb
@@ -9,6 +9,9 @@ Jasminerice.setup do |config|
   # you could access your tests at http://YOUR_SERVER_URL/jasmine
   #config.mount_at = '/jasmine'
 
+  # Specify a path where your specs can be found. Defaults to 'spec'
+  #config.spec_path = 'spec'
+
   # Specify a path where your fixutures can be found. Defaults to 'spec/javascripts/fixtures'
   config.fixture_path = 'spec/dummy/spec/javascripts/fixtures'
 end

--- a/spec/jasminerice/jasminerice_spec.rb
+++ b/spec/jasminerice/jasminerice_spec.rb
@@ -5,6 +5,7 @@ describe Jasminerice do
   it "has configuration properties" do
     expect(Jasminerice.mount).to be(true)
     expect(Jasminerice.mount_at).to eql('/jasmine')
+    expect(Jasminerice.spec_path).to eql('spec')
     expect(Jasminerice.fixture_path).to eql('spec/dummy/spec/javascripts/fixtures')
   end
 


### PR DESCRIPTION
I have a project that uses MiniTest, and thus all my tests are in a `tests/` directory, not a `spec/` directory. In the interest of keeping everything together I needed a way to specify where my tests lived.
